### PR TITLE
OTEL-1: Fix test regression in collector pipeline

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -170,5 +170,8 @@ func (m Metadata) Get(key string) []string {
 		return nil
 	}
 
-	return vals
+	ret := make([]string, len(vals))
+	copy(ret, vals)
+
+	return ret
 }


### PR DESCRIPTION
## Summary

**Fixes: [OTEL-1](https://sandeepsign.atlassian.net/browse/OTEL-1)**

### Root Cause
The `Metadata.Get()` method in `client/client.go` was modified to return a direct reference to internal slice data instead of a defensive copy. This optimization inadvertently violated the immutability contract documented for the Metadata type, causing `TestMetadata` to fail when tests modified the returned slice.

### Fix
Restored the defensive copy behavior in `Metadata.Get()`:
- Allocate a new slice with `make()`
- Copy values before returning
- Maintains backward compatibility with existing API consumers

### Test Results
| Test | Status |
|------|--------|
| TestNewContext | ✅ PASS |
| TestFromContext | ✅ PASS |
| **TestMetadata** | ✅ PASS |
| TestUninstantiatedMetadata | ✅ PASS |

```
ok      go.opentelemetry.io/collector/client    0.287s
```

### Files Changed
- `client/client.go` - 1 line changed (restored defensive copy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)